### PR TITLE
Changed reference.md and service-alerts.md to clarify ambiguity

### DIFF
--- a/gtfs-realtime/spec/en/examples/alerts.asciipb
+++ b/gtfs-realtime/spec/en/examples/alerts.asciipb
@@ -30,9 +30,16 @@ entity {
       # agency_id, route_id, route_type, stop_id, trip (see TripDescriptor)
       route_id: "219"
     }
-    # multiple selectors (informed_entity) can be given
+    # multiple selectors (informed_entity) can be included in one alert feed
     informed_entity {
       stop_id: "16230"
+    }
+    # multiple fields can be included in one informed_entity
+    informed_entity {
+      stop_id: "16299"
+      route_id: "100"
+      # This example means route 100 at stop 16299.
+      # This does not apply to any other stop on route 100 and any other route at stop 16299.
     }
 
     # cause of the alert - see gtfs-realtime.proto for valid values

--- a/gtfs-realtime/spec/en/examples/alerts.asciipb
+++ b/gtfs-realtime/spec/en/examples/alerts.asciipb
@@ -30,7 +30,7 @@ entity {
       # agency_id, route_id, route_type, stop_id, trip (see TripDescriptor)
       route_id: "219"
     }
-    # multiple selectors (informed_entity) can be included in one alert feed
+    # multiple selectors (informed_entity) can be included in one alert entity
     informed_entity {
       stop_id: "16230"
     }

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -372,7 +372,7 @@ Identification information for the vehicle performing the trip.
 
 ## _message_ EntitySelector
 
-A selector for an entity in a GTFS feed. The values of the fields should correspond to the appropriate fields in the GTFS feed. At least one specifier must be given. If several are given, then the matching has to apply to all the given specifiers.
+A selector for an entity in a GTFS feed. The values of the fields should correspond to the appropriate fields in the GTFS feed. At least one specifier must be given. If several are given, they should be interpreted as being joined by the `AND` operator and the combination of specifiers should match the information in the corresponding GTFS feed.
 
 #### Fields
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -372,7 +372,7 @@ Identification information for the vehicle performing the trip.
 
 ## _message_ EntitySelector
 
-A selector for an entity in a GTFS feed. The values of the fields should correspond to the appropriate fields in the GTFS feed. At least one specifier must be given. If several are given, they should be interpreted as being joined by the `AND` operator and the combination of specifiers should match the information in the corresponding GTFS feed.
+A selector for an entity in a GTFS feed. The values of the fields should correspond to the appropriate fields in the GTFS feed. At least one specifier must be given. If several are given, they should be interpreted as being joined by the logical `AND` operator and the combination of specifiers should match the information in the corresponding GTFS feed.  In other words, in order for an alert to apply to an entity it must match all of the provided `EntitySelector` fields.  For example, an `EntitySelector` that includes the fields `route_id: "5"` and `route_type: "3"` applies only to the `route_id: "5"` bus - it does not apply to any other routes of `route_type: "3"`.
 
 #### Fields
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -372,7 +372,7 @@ Identification information for the vehicle performing the trip.
 
 ## _message_ EntitySelector
 
-A selector for an entity in a GTFS feed. The values of the fields should correspond to the appropriate fields in the GTFS feed. At least one specifier must be given. If several are given, they should be interpreted as being joined by the logical `AND` operator and the combination of specifiers should match the information in the corresponding GTFS feed.  In other words, in order for an alert to apply to an entity it must match all of the provided `EntitySelector` fields.  For example, an `EntitySelector` that includes the fields `route_id: "5"` and `route_type: "3"` applies only to the `route_id: "5"` bus - it does not apply to any other routes of `route_type: "3"`.
+A selector for an entity in a GTFS feed. The values of the fields should correspond to the appropriate fields in the GTFS feed. At least one specifier must be given. If several are given, they should be interpreted as being joined by the logical `AND` operator and the combination of specifiers should match the information in the corresponding GTFS feed.  In other words, in order for an alert to apply to an entity it must match all of the provided EntitySelector fields.  For example, an EntitySelector that includes the fields `route_id: "5"` and `route_type: "3"` applies only to the `route_id: "5"` bus - it does not apply to any other routes of `route_type: "3"`.  If a producer wants an alert to apply to `route_id: "5"` as well as `route_type: "3"`, it should provide two separate EntitySelectors, one referencing `route_id: "5"` and another referencing `route_type: "3"`.
 
 #### Fields
 

--- a/gtfs-realtime/spec/en/service-alerts.md
+++ b/gtfs-realtime/spec/en/service-alerts.md
@@ -14,7 +14,7 @@ If no time is given, we will display the alert for as long as it is in the feed.
 
 ### Entity Selector
 
-Entity selector allows you specify exactly which parts of the network this alert affects, so that we can display only the most appropriate alerts to the user. You may include multiple entity selectors for alerts which affect multiple entities.
+Entity selector allows you specify exactly which parts of the network this alert affects, so that we can display only the most appropriate alerts to the user.
 
 Entities are selected using their GTFS identifiers, and you can select any of the following:
 
@@ -23,6 +23,8 @@ Entities are selected using their GTFS identifiers, and you can select any of th
 *   Route type - affects any route of this type. e.g. all subways.
 *   Trip - affects a particular trip
 *   Stop - affects a particular stop
+
+You may include multiple entity selectors. When multiple entities are selected in one Alert feed entity, they should be interpreted as being joined by the `AND` logical operator. If you would like to join the entities by the `OR` operator, you should include them in separate Alert feed entities.
 
 ### Cause
 

--- a/gtfs-realtime/spec/en/service-alerts.md
+++ b/gtfs-realtime/spec/en/service-alerts.md
@@ -14,7 +14,7 @@ If no time is given, we will display the alert for as long as it is in the feed.
 
 ### Entity Selector
 
-Entity selector allows you specify exactly which parts of the network this alert affects, so that we can display only the most appropriate alerts to the user.
+Entity selector allows you specify exactly which parts of the network this alert affects, so that we can display only the most appropriate alerts to the user. You may include multiple entity selectors for alerts which affect multiple entities.
 
 Entities are selected using their GTFS identifiers, and you can select any of the following:
 

--- a/gtfs-realtime/spec/en/service-alerts.md
+++ b/gtfs-realtime/spec/en/service-alerts.md
@@ -26,7 +26,7 @@ Entities are selected using their GTFS identifiers, and you can select any of th
 
 You may include more than one of the fields listed above in one `informed_entity`. When multiple fields are included in one `informed_entity`, they should be interpreted as being joined by the `AND` logical operator. In other words, the alert should only be applied in a context that meets all of the fields provided in an `informed_entity`. For example, if `route_id: "1"` and `stop_id: "5"` are both included in one `informed_entity`, then the alert should apply only to route 1 at stop 5.  It should NOT be applied to any other stop on route 1, and it should NOT be applied to any other route at stop 5.
 
-If you would like to represent an alert that affects more than one entity (e.g. an alert to all stops along route 1 and to all routes that visit stop 5) , you should add multiple `informed_entity` to your `alert`, with each of them applying to the affected entity (e.g. one `informed_entity` that includes route 1 and another `informed_entity` that includes stop 5).
+If you would like to represent an alert that affects more than one entity (e.g. an alert for both route 1 and stop 5) , you should add multiple `informed_entity` to your `alert`, with each of them applying to the affected entity (e.g. one `informed_entity` that includes route 1 and another `informed_entity` that includes stop 5).
 
 ### Cause
 

--- a/gtfs-realtime/spec/en/service-alerts.md
+++ b/gtfs-realtime/spec/en/service-alerts.md
@@ -24,7 +24,9 @@ Entities are selected using their GTFS identifiers, and you can select any of th
 *   Trip - affects a particular trip
 *   Stop - affects a particular stop
 
-You may include multiple entity selectors. When multiple entities are selected in one Alert feed entity, they should be interpreted as being joined by the `AND` logical operator. If you would like to join the entities by the `OR` operator, you should include them in separate Alert feed entities.
+You may include more than one of the fields listed above in one `informed_entity`. When multiple fields are included in one `informed_entity`, they should be interpreted as being joined by the `AND` logical operator. In other words, the alert should only be applied in a context that meets all of the fields provided in an `informed_entity`. For example, if `route_id: "1"` and `stop_id: "5"` are both included in one `informed_entity`, then the alert should apply only to route 1 at stop 5.  It should NOT be applied to any other stop on route 1, and it should NOT be applied to any other route at stop 5.
+
+If you would like to represent an alert that affects more than one entity (e.g. an alert to all stops along route 1 and to all routes that visit stop 5) , you should add multiple `informed_entity` to your `alert`, with each of them applying to the affected entity (e.g. one `informed_entity` that includes route 1 and another `informed_entity` that includes stop 5).
 
 ### Cause
 


### PR DESCRIPTION
Clarifying ambiguity in Alert.EntitySelector. Problem can be viewed at https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/19