### PR TITLE
changed reference.md to clarify the use of schedule_relationship:NO_DATA

### DIFF
--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -188,7 +188,7 @@ The relation between this StopTime and the static schedule.
 |-------------|---------------|
 | **SCHEDULED** | The vehicle is proceeding in accordance with its static schedule of stops, although not necessarily according to the times of the schedule. This is the **default** behavior. At least one of arrival and departure must be provided. |
 | **SKIPPED** | The stop is skipped, i.e., the vehicle will not stop at this stop. Arrival and departure are optional. |
-| **NO_DATA** | No data is given for this stop. It indicates that there is no realtime information available. When set NO_DATA is propagated through subsequent stops so this is the recommended way of specifying from which stop you do not have realtime information. When NO_DATA is set neither arrival nor departure should be supplied. |
+| **NO_DATA** | No data is given for this stop. It indicates that there is no realtime information available. When set NO_DATA is propagated through subsequent stops so this is the recommended way of specifying from which stop you do not have realtime information. When NO_DATA is set neither arrival nor departure should be supplied. In addition, delay from previous stops is not propagated through the NO_DATA stop and subsequent stops. |
 
 ## _message_ VehiclePosition
 

--- a/gtfs-realtime/spec/en/trip-updates.md
+++ b/gtfs-realtime/spec/en/trip-updates.md
@@ -35,7 +35,7 @@ For the same trip instance, three [StopTimeUpdates](reference.md#StopTimeUpdate)
 
 *   delay of 300 seconds for stop_sequence 3
 *   delay of 60 seconds for stop_sequence 8
-*   delay of unspecified duration for stop_sequence 10
+*   delay of unspecified duration for stop_sequence 10 (this is done by setting [schedule_relationship](https://github.com/MobilityData/transit/blob/master/gtfs-realtime/spec/en/reference.md#enum-schedulerelationship):NO_DATA
 
 This will be interpreted as:
 

--- a/gtfs-realtime/spec/en/trip-updates.md
+++ b/gtfs-realtime/spec/en/trip-updates.md
@@ -35,7 +35,7 @@ For the same trip instance, three [StopTimeUpdates](reference.md#StopTimeUpdate)
 
 *   delay of 300 seconds for stop_sequence 3
 *   delay of 60 seconds for stop_sequence 8
-*   delay of unspecified duration for stop_sequence 10 (this is done by setting [schedule_relationship](https://github.com/MobilityData/transit/blob/master/gtfs-realtime/spec/en/reference.md#enum-schedulerelationship):NO_DATA
+*   delay of unspecified duration for stop_sequence 10 (this is done by setting [schedule_relationship](https://github.com/MobilityData/transit/blob/master/gtfs-realtime/spec/en/reference.md#enum-schedulerelationship):NO_DATA)
 
 This will be interpreted as:
 


### PR DESCRIPTION
Refer to issue v285: https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/285