### PR TITLE
Add voter info requirement to CHANGES.md

### DIFF
--- a/gtfs-realtime/CHANGES.md
+++ b/gtfs-realtime/CHANGES.md
@@ -37,7 +37,8 @@ When a producer or consumer is interested in adding a new field to the GTFS Real
 		- Voter name
 		- Organization affiliation
 		- Software where the proposed change has been implemented (with link, if applicable)
-		- Voter category (GTFS producer or GTFS consumer) 
+		- Voter category (GTFS producer or GTFS consumer)
+	- It is recomended that voters include name and organization affiliation in their Github profile. 
   	- Votes before the start of the voting period are not considered.
 1. The proposal is accepted if there is a unanimous consensus yes with at least 3 votes.
   	- The proposer's vote does not count towards the 3 vote total. For example, if Proposer X creates a pull request and votes yes, and User Y and Z vote yes, this is counted as 2 total yes votes.

--- a/gtfs-realtime/CHANGES.md
+++ b/gtfs-realtime/CHANGES.md
@@ -33,6 +33,11 @@ When a producer or consumer is interested in adding a new field to the GTFS Real
   	- During voting period only editorial changes to the proposal are allowed (typos, wording may change as long as it does not change the meaning).
   	- Anyone is allowed to vote yes/no in a form of comment to the pull request, and votes can be changed until the end of the voting period.
     If a voter changes her vote, it is recommended to do it by updating the original vote comment by striking through the vote and writing the new vote.
+    - Comments containing a yes/no vote must also include the following information:
+		- Voter name
+		- Organization affiliation
+		- Software where the proposed change has been implemented (with link, if applicable)
+		- Voter category (GTFS producer or GTFS consumer) 
   	- Votes before the start of the voting period are not considered.
 1. The proposal is accepted if there is a unanimous consensus yes with at least 3 votes.
   	- The proposer's vote does not count towards the 3 vote total. For example, if Proposer X creates a pull request and votes yes, and User Y and Z vote yes, this is counted as 2 total yes votes.

--- a/gtfs-realtime/CHANGES.md
+++ b/gtfs-realtime/CHANGES.md
@@ -36,9 +36,9 @@ When a producer or consumer is interested in adding a new field to the GTFS Real
     - Comments containing a yes/no vote must also include the following information:
 		- Voter name
 		- Organization affiliation
-		- Software where the proposed change has been implemented (with link, if applicable)
 		- Voter category (GTFS producer or GTFS consumer)
-	- It is recomended that voters include name and organization affiliation in their Github profile. 
+		- Link to the relevant data or application if you are the consumer or producer that has implemented the proposed change as per step 5. 
+	- It is recommended that voters include name and organization affiliation in their Github profile. 
   	- Votes before the start of the voting period are not considered.
 1. The proposal is accepted if there is a unanimous consensus yes with at least 3 votes.
   	- The proposer's vote does not count towards the 3 vote total. For example, if Proposer X creates a pull request and votes yes, and User Y and Z vote yes, this is counted as 2 total yes votes.

--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -18,6 +18,11 @@ The official specification, reference and documentation are written in English. 
   	- During voting period only editorial changes to the proposal are allowed (typos, wording may change as long as it does not change the meaning).
   	- Anyone is allowed to vote yes/no in a form of comment to the pull request, and votes can be changed until the end of the voting period.
     If a voter changes her vote, it is recommended to do it by updating the original vote comment by striking through the vote and writing the new vote.
+	- Comments containing a yes/no vote must also include the following information:
+		- Voter name
+		- Organization affiliation
+		- Software where the proposed change has been implemented (with link, if applicable)
+		- Voter category (GTFS producer or GTFS consumer)
   	- Votes before the start of the voting period are not considered.
 1. The proposal is accepted if there is a unanimous consensus yes with at least 3 votes.
   	- The proposer's vote does not count towards the 3 vote total. For example, if Proposer X creates a pull request and votes yes, and User Y and Z vote yes, this is counted as 2 total yes votes.

--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -20,10 +20,10 @@ The official specification, reference and documentation are written in English. 
     If a voter changes her vote, it is recommended to do it by updating the original vote comment by striking through the vote and writing the new vote.
 	- Comments containing a yes/no vote must also include the following information:
 		- Voter name
-		- Organization affiliation
-		- Software where the proposed change has been implemented (with link, if applicable)
+		- Organization affiliation 
 		- Voter category (GTFS producer or GTFS consumer)
-	- It is recomended that voters include name and organization affiliation in their Github profile
+		- Link to the relevant data or application if you are the consumer or producer that has implemented the proposed change as per step 5. 
+	- It is recommended that voters include name and organization affiliation in their Github profile
   	- Votes before the start of the voting period are not considered.
 1. The proposal is accepted if there is a unanimous consensus yes with at least 3 votes.
   	- The proposer's vote does not count towards the 3 vote total. For example, if Proposer X creates a pull request and votes yes, and User Y and Z vote yes, this is counted as 2 total yes votes.

--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -23,6 +23,7 @@ The official specification, reference and documentation are written in English. 
 		- Organization affiliation
 		- Software where the proposed change has been implemented (with link, if applicable)
 		- Voter category (GTFS producer or GTFS consumer)
+	- It is recomended that voters include name and organization affiliation in their Github profile
   	- Votes before the start of the voting period are not considered.
 1. The proposal is accepted if there is a unanimous consensus yes with at least 3 votes.
   	- The proposer's vote does not count towards the 3 vote total. For example, if Proposer X creates a pull request and votes yes, and User Y and Z vote yes, this is counted as 2 total yes votes.


### PR DESCRIPTION
This PR alters the GTFS change process to require some basic information from people who vote on a GTFS proposal. The information required is listed below. 

- Voter name
- Organizational affiliation
- Software where the change has been implement (if applicable)
- Voter category (producer or consumer) 