### PR TITLE
Add GTFS-RT platform changes

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -240,7 +240,15 @@ message TripUpdate {
       UNSCHEDULED = 3;
     }
     optional ScheduleRelationship schedule_relationship = 5
-        [default = SCHEDULED];
+    [default = SCHEDULED];
+
+    // Provides the updated values for the stop time.
+    message StopTimeProperties {
+      // Supports real-time platform changes. Refers to a stop_id defined in the GTFS stops.txt. This stop_id must
+      // belong to the same station as the stop originally defined in GTFS stop_times.txt.
+      optional string platform_id = 1;
+    }
+    optional StopTimeProperties stop_time_properties = 6;
 
     // The extensions namespace allows 3rd-party developers to extend the
     // GTFS Realtime Specification in order to add and evaluate new features

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -49,6 +49,7 @@ Fields labeled as **experimental** are subject to change and not yet formally ad
             *   [StopTimeUpdate](#message-stoptimeupdate)
                 *   [StopTimeEvent](#message-stoptimeevent)
                 *   [ScheduleRelationship](#enum-schedulerelationship)
+                *   [StopTimeProperties](#message-stoptimeproperties)
         *   [VehiclePosition](#message-vehicleposition)
             *   [TripDescriptor](#message-tripdescriptor)
                 *   [ScheduleRelationship](#enum-schedulerelationship-1)
@@ -177,8 +178,8 @@ The update is linked to a specific stop either through stop_sequence or stop_id,
 
 | _**Field Name**_ | _**Type**_ | _**Required**_ | _**Cardinality**_ | _**Description**_ |
 |------------------|------------|----------------|-------------------|-------------------|
-| **stop_sequence** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Conditionally required | One | Must be the same as in stop_times.txt in the corresponding GTFS feed.  Either stop_sequence or stop_id must be provided within a StopTimeUpdate - both fields cannot be empty.  stop_sequence is required for trips that visit the same stop_id more than once (e.g., a loop) to disambiguate which stop the prediction is for. |
-| **stop_id** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Conditionally required | One | Must be the same as in stops.txt in the corresponding GTFS feed. Either stop_sequence or stop_id must be provided within a StopTimeUpdate - both fields cannot be empty. |
+| **stop_sequence** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Conditionally required | One | Must be the same as in stop_times.txt in the corresponding GTFS feed.  Either stop_sequence or stop_id must be provided within a StopTimeUpdate - both fields cannot be empty.  stop_sequence is required for trips that visit the same stop_id more than once (e.g., a loop) to disambiguate which stop the prediction is for. The pairing of stop_sequence and stop_id must match the corresponding values in GTFS stop_times.txt for this trip. |
+| **stop_id** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Conditionally required | One | Must be the same as in stops.txt in the corresponding GTFS feed. Either stop_sequence or stop_id must be provided within a StopTimeUpdate - both fields cannot be empty. The pairing of stop_sequence and stop_id must match the corresponding values in GTFS stop_times.txt for this trip. |
 | **arrival** | [StopTimeEvent](#message-stoptimeevent) | Conditionally required | One | If schedule_relationship is empty or SCHEDULED, either arrival or departure must be provided within a StopTimeUpdate - both fields cannot be empty. arrival and departure may both be empty when schedule_relationship is SKIPPED.  If schedule_relationship is NO_DATA, arrival and departure must be empty. |
 | **departure** | [StopTimeEvent](#message-stoptimeevent) | Conditionally required | One | If schedule_relationship is empty or SCHEDULED, either arrival or departure must be provided within a StopTimeUpdate - both fields cannot be empty. arrival and departure may both be empty when schedule_relationship is SKIPPED.  If schedule_relationship is NO_DATA, arrival and departure must be empty. |
 | **schedule_relationship** | [ScheduleRelationship](#enum-schedulerelationship) | Optional | One | The default relationship is SCHEDULED. |
@@ -195,6 +196,16 @@ The relation between this StopTime and the static schedule.
 | **SKIPPED** | The stop is skipped, i.e., the vehicle will not stop at this stop. Arrival and departure are optional. When set `SKIPPED` is not propagated to subsequent stops in the same trip (i.e., the vehicle will stop at subsequent stops in the trip unless those stops also have a `stop_time_update` with `schedule_relationship: SKIPPED`). Delay from a previous stop in the trip *does* propagate over the `SKIPPED` stop. In other words, if a `stop_time_update` with an `arrival` or `departure` prediction is not set for a stop after the `SKIPPED` stop, the prediction upstream of the `SKIPPED` stop will be propagated to the stop after the `SKIPPED` stop and subsequent stops in the trip until a `stop_time_update` for a subsequent stop is provided.  |
 | **NO_DATA** | No data is given for this stop. It indicates that there is no realtime information available. When set NO_DATA is propagated through subsequent stops so this is the recommended way of specifying from which stop you do not have realtime information. When NO_DATA is set neither arrival nor departure should be supplied. |
 | **UNSCHEDULED** | The vehicle is operating a frequency-based trip (GTFS frequencies.txt with exact_times = 0). This value should not be used for trips that are not defined in GTFS frequencies.txt, or trips in GTFS frequencies.txt with exact_times = 1. Trips containing `stop_time_updates` with `schedule_relationship: UNSCHEDULED` must also set the TripDescriptor `schedule_relationship: UNSCHEDULED` <br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future.<br>.
+
+## _message_ StopTimeProperties
+
+Realtime update for certain properties defined within GTFS stop_times.txt. 
+
+#### Fields
+
+| _**Field Name**_ | _**Type**_ | _**Required**_ | _**Cardinality**_ | _**Description**_ |
+|------------------|------------|----------------|-------------------|-------------------|
+| **platform_id** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | Supports real-time platform changes at stations. Refers to a stop_id defined in the GTFS stops.txt. This stop_id must belong to the same station as the stop originally defined in GTFS stop_times.txt for the `stop_sequence` defined in the StopTimeUpdate. If this field is populated, StopTimeUpdate `stop_sequence` must be populated and StopTimeUpdate `stop_id` should not be populated. |
 
 ## _message_ VehiclePosition
 


### PR DESCRIPTION
### Background
Several producers and consumers have expressed the need to reflect platform changes within stations in real-time. However, the GTFS-RT spec currently does not officially support this use case. The spec unclear whether changing stop_id to a value other than what is defined in GTFS stop_times.txt for a given stop_sequence is an error [1].

### Proposal

This proposal adds a new message and field within `StopTimeUpdates`, `StopTimeProperties.platform_id` which can be used to specify changes to stop_ids within the same parent station as static GTFS.

This pull request is a subset of the GTFS-ServiceChanges v3.1 spec:
https://bit.ly/gtfs-service-changes-v3_1

This pull request isolates the changes necessary to add the platform changes feature, and removes the rest of the ServiceChanges features. Because platform changes is currently implemented by a few producers and at least one consumer by changing the StopTimeUpdate `stop_id` [2], this feature could be adopted prior to the rest of the entire ServiceChanges spec. with minimal changes to existing feeds.

This proposal uses the terminology `platform_id` for a new field, instead of (re)using `stop_id` for several reasons:
1. The use case for this new field is only changing stop_ids within a station - producers cannot put any stop_id in this field and expect consumers to be able to process this change to the trip geometry quickly. To avoid confusion by producers and consumers with other use cases of changing stops within a trip (e.g., detours), the field is therefore narrowly named `platform_id` instead of `stop_id`.
1. ServiceChanges defines a more robust solution for detours that changes/adds stops within the trip by adding a new `Trip` object with new `StopTime` objects. However, it takes consumers longer to process these new trips due to pre-processing required, and therefore this approach is not suitable for platform changes that must be processed in the same order-of-magnitude of time as arrival prediction changes. Therefore, platform changes should be implemented differently.
1. Re-using the existing StopTimeUpdate `stop_id` field to change platforms causes issues with feed validation - it's not clear whether the change from the static GTFS stop_id is intentional or an error. To clarify this situation, this proposal also adds documentation saying StopTimeUpdate stop_id and stop_sequence pairings must match static GTFS - in other words, it clarifies that these fields are selectors to specify the stop, and cannot be modified in real-time.

Future proposals may add other fields defined in GTFS stop_times.txt to the `StopTimeProperties` message  (e.g., pickup_type, drop_off_type, stop_headsign, shape_dist_traveled) so they can be changed in real-time. See the [ServiceChanges proposal](https://docs.google.com/document/d/1oPfQ6Xvui0g3xiy1pNiyu5cWFLhvrTVyvYsMVKGyGWM/edit#bookmark=id.m61cxqvifvmg) for more info.

[1] https://github.com/google/transit/pull/81
[2] https://groups.google.com/d/msg/gtfs-realtime/BZOfsVeI2Cc/gIUjGbkCBAAJ