### PR TITLE
Update README.md to make it clear this fork is for internal use only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+MobilityData's internal fork of the Official GTFS Specification repository. This fork is used to draft pull requests before sharing them on the official repo. [Go to the official repo to ask questions and open issues](https://github.com/google/transit). 
+
 The repository contains specification to manipulate General Transit
 Feed Specification (GTFS) and GTFS Realtime:
 * [GTFS](/gtfs/README.md)


### PR DESCRIPTION
Update README so no one posts issues here and is directed to https://github.com/google/transit