### PR TITLE
Fix description rendering for locations.geojson

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -737,6 +737,7 @@ Assigns stops from stops.txt to location groups.
 File: **Optional**
 
 Defines zones where riders can request either pickup or drop off by on-demand services. These zones are represented as GeoJSON polygons.
+
 - This file uses a subset of the GeoJSON format, described in [RFC 7946](https://tools.ietf.org/html/rfc7946).
 - The `locations.geojson` file must contain a `FeatureCollection`.
 - A `FeatureCollection` defines various stop locations where riders may request pickup or drop off.


### PR DESCRIPTION
The description of `locations.geojson` doesn't render properly on gtfs.org:

<img width="1104" alt="Screenshot 2024-04-10 at 12 36 47 PM" src="https://github.com/MobilityData/transit/assets/63653518/067fdd54-2e83-4254-bdea-1860ba385db5">

This PR adds a blank line, which should fix the issue (based on some [previous experience](https://github.com/MobilityData/gtfs.org/commit/71601fcac7c4cad8e2302bb0487c2a0c7f4aa53d) I had with this problem).