### PR TITLE
Add network sets and relax constraint on networks in fare_leg_join_rules.txt

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -641,9 +641,9 @@ Defines network set identifiers that apply for fare leg rules.
 
 ### network_set_elements.txt
 
-File: **Conditionally Forbidden**
+File: **Optional**
 
-Primary key (`route_id`)
+Primary key (`network_set_id, network_id`)
 
 Assigns networks from [networks.txt](#networkstxt) to network sets. 
 


### PR DESCRIPTION
<!--USE THIS TEMPLATE AS A REFERENCE AND MODIFY AND REMOVE SECTIONS TO BEST FIT YOUR PROPOSAL-->

## Summary
This proposal:
1) Adds network set predicates which allow for matching with collections of networks in `fare_leg_rules.txt`
2) Relaxes the constraint that only legs with the same network can be joined in `fare_leg_join_rules.txt`, thus allowing joins across networks.

## Describe the Problem
1) There needs to be a method to define how a fare leg rule should match an effective fare leg (resulting from a `fare_leg_join_rule.txt` join) that spans multiple networks.
2) The current spec says in `fare_leg_join_rules.txt` that a leg with a `network_id` can only be joined to another leg with the same `network_id`, which is restrictive and does not represent multiple real-world cases,

## Use Cases
Network sets can be used in cases where routes from different networks can be priced together under the same fare scheme.

Three real-world cases are detailed in the [Network sets real-world case research](https://docs.google.com/document/d/16k9Ljaj9ej0aD1VocYR8PL4nYYcecwfRCE_UeAfHZ8A/edit?usp=sharing) document, including STM's Airport bus, the ORCA fare scheme in Seattle, and the multiple fare tiers of LeCar in the Aix-Marseille-Provence region.

## Proposed Solution
The full proposal can be found [here](https://docs.google.com/document/d/16IIvlVCqdHw3z84Xv_wGspRcl5uKHsvVKqdrZTBk1GI/edit?usp=sharing). It includes:
1) Adding Network Set Predicates to match effective fare legs to rules in `fare_leg_rules.txt`. These network sets are defined in `network_sets.txt` and mapped to routes in `network_set_elements.txt`.
2) For Network Sets to be usable, it is necessary to relax the constraint that only legs with the same network can be joined in `fare_leg_join_rules.txt`. By allowing leg joins across different networks, the effective fare leg will contain multiple `network_ids`.


This proposal was discussed and its scope was defined in multiple Fares v2 Working Group meetings. For further details, please check:
- [Meeting notes - 2025/05/27
](https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit?tab=t.0#heading=h.yrj8wb4jpc5u)
- [Meeting notes - 2025/07/22](https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit?tab=t.0#heading=h.awz1jbcydmhi)

## Type of change

<!--Please select the relevant change type.--> 

GTFS Schedule
- [ ✅  ] Functional Change
- [ ] Non-Functional Change
- [ ] Documentation Maintenance

GTFS Realtime
- [ ] Specification Change
- [ ] Specification Change (Experimental Field)

## Additional Information
<!--Include any relevant background, context, or supporting details that may help reviewers understand the rationale behind this proposal. This could include links to discussions, technical documentation, or related proposals.-->

## Proposed Discussion Period
We propose that the discussion period last 14 calendar days from the date this PR is raised.

## Testing Details
<!--If applicable, confirm the identity of the Consumer(s) and Producer(s) who will test the changes in the Pull Request comment section and document them below.-->

- Consumer(s): <!--List the entities that will consume the data and test the proposed change.-->
- Producer(s): <!--List the entities that will produce the data and test the proposed change.-->
- Estimated Testing Period: <!--Specify the duration for testing.-->

## Proposal Update Tracker 
<!--Track changes to this Pull Request post over time, including edits and updates to the proposal. Regularly update this section to summarize major points discussed in the PR, ensuring a clear record of key decisions and modifications.-->

| Date       | Update Description |
|------------|--------------------|
| (2025-09-08) | PR drafted in fork |

## Checklist

- [ ] I have read and understood the [GTFS Change process](https://github.com/google/transit/tree/master/gtfs/Governance/change-process.md).
- [ ] I have read and understood the [GTFS Guiding Principles](https://github.com/google/transit/tree/master/gtfs/Governance/guiding-principles.md). 
- [ ] I understand the [Role of Advocate and the Responsibilities](https://github.com/google/transit/tree/master/gtfs/Governance/roles.md) attached to it. 
- [ ] I have signed the [Contributor License Agreement (CLA)](https://cla.developers.google.com/about/google-individual).
- [ ] I have ensured that this proposal is not covered by an existing Pull Request.
